### PR TITLE
Make shallow clones of audited repositories

### DIFF
--- a/lib/auditor/source_updater.rb
+++ b/lib/auditor/source_updater.rb
@@ -17,7 +17,7 @@ module Auditor
 
     def clone!
       puts "Cloning code to #{project_root}..."
-      Command.execute("git clone #{repo_url} #{project_root}")
+      Command.execute("git clone --depth 1 #{repo_url} #{project_root}")
     end
 
     def pull!


### PR DESCRIPTION
We don't really need full history of each repo.
Could be optimized even further by fetching only `Gemfile.lock`.